### PR TITLE
BE: CORS 설정 추가 및 .gitignore 수정 (#2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,11 @@ out/
 
 ### VS Code ###
 .vscode/
+
+# Spring Boot application config
+application.yml
+application-*.yml
+
+### Docker ###
+Dockerfile
+docker-compose.yml

--- a/src/main/java/org/example/backend/config/JwtAuthenticationFilter.java
+++ b/src/main/java/org/example/backend/config/JwtAuthenticationFilter.java
@@ -28,6 +28,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException, IOException {
+        String path = request.getRequestURI();
+
+        // 로그인, 회원가입
+        // 인증 제외 경로 → 필터 패스
+        if (path.startsWith("/api/auth")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         String token = resolveToken(request);
 
         if (token != null && jwtTokenProvider.validateToken(token)) {
@@ -40,11 +49,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 
             SecurityContextHolder.getContext().setAuthentication(auth);
-
-//            System.out.println("토큰: " + token);
-//            System.out.println("유효?: " + jwtTokenProvider.validateToken(token));
-//            System.out.println("인증 객체: " + SecurityContextHolder.getContext().getAuthentication());
-
         }
 
         filterChain.doFilter(request, response);
@@ -58,4 +62,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
         return null;
     }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getServletPath();
+        return path.startsWith("/api/auth/");
+    }
+
 }

--- a/src/main/java/org/example/backend/config/SecurityConfig.java
+++ b/src/main/java/org/example/backend/config/SecurityConfig.java
@@ -10,6 +10,11 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 
 @Configuration
@@ -32,6 +37,22 @@ public class SecurityConfig {
 
         return http.build();
     }
+
+    // CORS 설정
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("http://localhost:3000", "http://localhost:5173"));     // 프론트엔드 주소
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true); // 쿠키/인증정보 포함 허용
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+
+        return source;
+    }
+
 
     @Bean
     public PasswordEncoder passwordEncoder() {


### PR DESCRIPTION
### 변경 목적
- 프론트엔드와의 연동을 위해 CORS 설정을 추가
- 불필요한 민감 파일(application.yml 등) 및 docker-compose.yml을 Git 추적에서 제외하기 위해 .gitignore 수정

### 구현 내용
- SecurityConfig에 CORS 허용 설정 추가
- .gitignore에 application.yml, application-*.yml, docker-compose.yml 규칙 추가

### 참고 사항
- 추후 다른 환경 설정 파일도 gitignore 적용 필요
- 로컬/도커 환경 모두 정상 동작 확인
