### PR TITLE
BE: Request/Response DTO 추가 및 Swagger 구현 (#3)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.4'
+    id 'org.springframework.boot' version '3.3.4'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -28,8 +28,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-webflux' // WebClient 사용 시
-
+    // WebClient만 쓰고 싶을 때
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -38,6 +38,8 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     implementation 'mysql:mysql-connector-java:8.0.33'
+
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
 
   db:
     image: mysql:8.0
-    container_name: commuter_db
+    container_name: commuter
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: 1234
@@ -30,6 +30,11 @@ services:
       - db_data:/var/lib/mysql
     networks:
       - backend_net
+    healthcheck:
+      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
 volumes:
   db_data:

--- a/src/main/java/org/example/backend/config/SecurityConfig.java
+++ b/src/main/java/org/example/backend/config/SecurityConfig.java
@@ -27,6 +27,13 @@ public class SecurityConfig {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
+                        // Swagger 관련 엔드포인트 허용
+                        .requestMatchers(
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/v3/api-docs/**",
+                                "/api-docs/**"
+                        ).permitAll()
                         .requestMatchers("/api/auth/**").permitAll() // 로그인/회원가입 허용
                         .requestMatchers("/api/hello").permitAll() // 테스트용 API 허용
                         .requestMatchers("/api/protected").authenticated()  // 인증만 필요

--- a/src/main/java/org/example/backend/controller/AuthController.java
+++ b/src/main/java/org/example/backend/controller/AuthController.java
@@ -1,30 +1,48 @@
 package org.example.backend.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.example.backend.config.JwtTokenProvider;
 import org.example.backend.domain.User;
 import org.example.backend.domain.UserRepository;
+import org.example.backend.dto.common.ApiResponse;
+import org.example.backend.dto.request.LoginRequest;
+import org.example.backend.dto.request.SignupRequest;
+import org.example.backend.dto.response.LoginResponse;
+import org.example.backend.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.HashMap;
 import java.util.Map;
 
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
+@Tag(name = "인증 API", description = "회원가입 및 로그인 관련 API")
 public class AuthController {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
 
+    @Operation(summary = "회원가입", description = "새로운 사용자 등록")
     @PostMapping("/signup")
-    public String signup(@RequestBody Map<String, String> body) {
-        String email = body.get("email");
-        String password = passwordEncoder.encode(body.get("password"));
-        String nickname = body.get("nickname");
+    public ResponseEntity<ApiResponse<Void>> singup(@RequestBody SignupRequest request) {
+        String email = request.getEmail();
+        String password = passwordEncoder.encode(request.getPassword());
+        String nickname = request.getNickname();
+
+        // 이메일 중복 체크
+        if(userRepository.findByEmail(email).isPresent()) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body(ApiResponse.error(ErrorCode.DUPLICATE_EMAIL));
+        }
 
         User user = User.builder()
                 .email(email)
@@ -35,18 +53,28 @@ public class AuthController {
                 .build();
 
         userRepository.save(user);
-        return "회원가입 성공";
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(null, "회원가입이 완료되었습니다.", HttpStatus.CREATED));
     }
 
+    @Operation(summary = "로그인", description = "이메일과 비밀번호를 입력하여 토큰 발급")
     @PostMapping("/login")
-    public String login(@RequestBody Map<String, String> body) {
-        User user = userRepository.findByEmail(body.get("email"))
-                .orElseThrow(() -> new RuntimeException("존재하지 않는 이메일"));
+    public ResponseEntity<ApiResponse<LoginResponse>> login(@RequestBody LoginRequest request){
+        User user = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new RuntimeException(ErrorCode.USER_NOT_FOUND.getMessage()));
 
-        if (!passwordEncoder.matches(body.get("password"), user.getPassword())) {
-            throw new RuntimeException("비밀번호 불일치");
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(ApiResponse.error(ErrorCode.INVALID_PASSWORD));
         }
 
-        return jwtTokenProvider.createToken(user.getEmail());
+        // Access Token + Refresh Token 생성
+        String accessToken = jwtTokenProvider.createToken(user.getEmail());
+        String refreshToken = jwtTokenProvider.createToken(user.getEmail());
+
+        LoginResponse response = new LoginResponse(accessToken, refreshToken, user.getEmail(), user.getNickname());
+
+        return ResponseEntity.ok(ApiResponse.success(response, "로그인이 완료되었습니다", HttpStatus.OK));
     }
 }

--- a/src/main/java/org/example/backend/dto/common/ApiResponse.java
+++ b/src/main/java/org/example/backend/dto/common/ApiResponse.java
@@ -1,0 +1,74 @@
+package org.example.backend.dto.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.backend.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.ALWAYS)
+public class ApiResponse<T> {
+    private boolean success;
+    private String message;
+    private T data;
+    private String errorCode;
+    private int statusCode;
+    private LocalDateTime timestamp;
+
+    public static <T> ApiResponse<T> success(T data) {
+        return ApiResponse.<T>builder()
+                .success(true)
+                .data(data)
+                .statusCode(HttpStatus.OK.value())
+                .timestamp(LocalDateTime.now())
+                .build();
+    }
+
+    public static <T> ApiResponse<T> success(T data, String message, HttpStatus status) {
+        return ApiResponse.<T>builder()
+                .success(true)
+                .message(message)
+                .data(data)
+                .statusCode(status.value())
+                .timestamp(LocalDateTime.now())
+                .build();
+    }
+
+    public static <T> ApiResponse<T> error(String message) {
+        return ApiResponse.<T>builder()
+                .success(false)
+                .message(message)
+                .statusCode(HttpStatus.INTERNAL_SERVER_ERROR.value())
+                .timestamp(LocalDateTime.now())
+                .build();
+    }
+
+    public static <T> ApiResponse<T> error(String message, String errorCode) {
+        return ApiResponse.<T>builder()
+                .success(false)
+                .message(message)
+                .errorCode(errorCode)
+                .statusCode(HttpStatus.INTERNAL_SERVER_ERROR.value())
+                .timestamp(LocalDateTime.now())
+                .build();
+    }
+
+    public static <T> ApiResponse<T> error(ErrorCode errorCode) {
+        return ApiResponse.<T>builder()
+                .success(false)
+                .message(errorCode.getMessage())
+                .errorCode(errorCode.getCode())
+                .statusCode(errorCode.getStatus().value())
+                .timestamp(LocalDateTime.now())
+                .build();
+    }
+
+}

--- a/src/main/java/org/example/backend/dto/request/LoginRequest.java
+++ b/src/main/java/org/example/backend/dto/request/LoginRequest.java
@@ -1,0 +1,15 @@
+package org.example.backend.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LoginRequest {
+    @Schema(example = "test@example.com", description = "사용자 이메일")
+    private String email;
+
+    @Schema(example = "1234", description = "비밀번호")
+    private String password;
+}

--- a/src/main/java/org/example/backend/dto/request/SignupRequest.java
+++ b/src/main/java/org/example/backend/dto/request/SignupRequest.java
@@ -1,0 +1,18 @@
+package org.example.backend.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SignupRequest {
+    @Schema(example = "test@example.com", description = "사용자 이메일")
+    private String email;
+
+    @Schema(example = "testuser", description = "사용자 닉네임")
+    private String nickname;
+
+    @Schema(example = "1234", description = "비밀번호")
+    private String password;
+}

--- a/src/main/java/org/example/backend/dto/response/LoginResponse.java
+++ b/src/main/java/org/example/backend/dto/response/LoginResponse.java
@@ -1,0 +1,23 @@
+package org.example.backend.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class LoginResponse {
+    @Schema(example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+    private String accessToken;
+
+    @Schema(example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+    private String refreshToken;
+
+    @Schema(example = "test@example.com")
+    private String email;
+
+    @Schema(example = "testuser")
+    private String nickname;
+}

--- a/src/main/java/org/example/backend/dto/response/SignupResponse.java
+++ b/src/main/java/org/example/backend/dto/response/SignupResponse.java
@@ -1,0 +1,18 @@
+package org.example.backend.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SignupResponse {
+    @Schema(example = "test@example.com")
+    private String email;
+
+    @Schema(example = "testuser")
+    private String nickname;
+
+    @Schema(example = "회원가입 성공")
+    private String message;
+}

--- a/src/main/java/org/example/backend/exception/ErrorCode.java
+++ b/src/main/java/org/example/backend/exception/ErrorCode.java
@@ -1,0 +1,52 @@
+package org.example.backend.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "U001", "이미 가입하신 이메일입니다."),
+    DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "U002", "이미 존재하는 닉네임입니다."),
+    INVALID_USERNAME(HttpStatus.BAD_REQUEST, "U003", "사용자명은 필수입니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U004", "존재하지 않는 사용자입니다."),
+    INVALID_PASSWORD(HttpStatus.NOT_FOUND, "U005", "비밀번호가 일치하지 않습니다"),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "U006", "인증에 실패했습니다."),
+    EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "U007", "이메일 정보가 없습니다"),
+    USER_NOT_ACTIVE(HttpStatus.FORBIDDEN, "U008", "비활성화 회원입니다."),
+    SOCIAL_USER_EMAIL_OR_PASSWORD_CHANGE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "U009", "소셜 로그인 사용자는 비밀번호 변경이 불가능합니다."),
+    PASSWORD_RESET_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "U009", "비밀번호 리셋 토큰이 올바르지 않습니다."),
+    PASSWORD_RESET_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "U010", "비밀번호 리셋 토큰이 만료되었습니다."),
+
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED,"A001", "유효하지 않은 액세스 토큰입니다."),
+    EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED,"A002", "만료된 엑세스 토큰입니다."),
+
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED,"R001", "유효하지 않은 리프레시 토큰입니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED,"R002", "Redis에 해당 리프레시 토큰이 존재하지 않습니다."),
+    REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED,"R003", "Redis에 토큰과 맞지 않는 토큰입니다."),
+
+    EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "E001", "이메일 발송에 실패했습니다."),
+    EMAIL_VERIFICATION_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "E002", "인증 코드가 만료되었습니다."),
+    EMAIL_VERIFICATION_CODE_INVALID(HttpStatus.BAD_REQUEST, "E003", "유효하지 않은 인증 코드입니다."),
+    EMAIL_VERIFICATION_CODE_REQUIRED(HttpStatus.BAD_REQUEST, "E004", "인증 코드를 입력해주세요."),
+    EMAIL_SEND_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "E005", "이메일 발송 횟수를 초과했습니다. 5분 후 다시 시도해주세요."),
+
+    EMPTY_PDF(HttpStatus.NOT_FOUND, "P001", "빈 PDF 입니다."),
+    TOO_MANY_CHARACTER(HttpStatus.BAD_REQUEST, "P002", "PDF 글자수를 초과하셨습니다."),
+    INVALID_PDF_FORMAT(HttpStatus.BAD_REQUEST, "P003", "PDF 형식이 아닙니다."),
+    PDF_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "P004", "PDF 파일 크기가 100MB를 초과합니다."),
+    NO_CHARACTER(HttpStatus.BAD_REQUEST, "P005", "이미지로만 구성된 PDF는 문제를 생성할 수 없습니다."),
+    JSON_SERIALIZATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "J001", "JSON 직렬화에 실패했습니다."),
+    JSON_DESERIALIZATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "J002", "JSON 역직렬화에 실패했습니다."),
+
+    FOLDER_NOT_FOUND(HttpStatus.NOT_FOUND, "F001", "폴더를 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    ErrorCode(HttpStatus status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/org/example/backend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/backend/exception/GlobalExceptionHandler.java
@@ -1,0 +1,23 @@
+package org.example.backend.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.example.backend.dto.common.ApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        log.error("Unexpected Exception: ", e);
+
+        ApiResponse<Void> response = ApiResponse.error(
+                "시스템 오류가 발생했습니다. 잠시 후 다시 시도해주세요.",
+                "SYS001"
+        );
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}


### PR DESCRIPTION
### 변경 목적
- Swagger UI에서 회원가입/로그인 요청(Request)과 응답(Response) 추가
- Map<String, String> 기반의 요청/응답을 DTO 클래스로 분리

### 구현 내용
- 공통 응답 포맷(ApiResponse<T>) 추가
- 요청(Request) DTO 추가 : SignupRequest, LoginRequest 
- 응답(Response) DTO 추가 : SignupResponse, LoginResponse 
- AuthController 수정 : 기존 Map<String, String> → DTO 기반으로 변경
- Swagger UI 추가

### 참고 사항
- 현재 LoginResponse는 accessToken, refreshToken만 포함
- Swagger UI 경로: http://localhost:8000/swagger-ui/index.html